### PR TITLE
Fix problem with uglify-js package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var uglify = require('uglify-js')
-  , jsClient = uglify.minify(__dirname + '/client.js').code
+  , clientCode = require('fs').readFileSync(__dirname + '/client.js').toString()
+  , jsClient = uglify.minify(clientCode).code
   , winston
   ;
 
@@ -21,7 +22,7 @@ function parseMetadataSafely(meta) {
     parsedMeta = JSON.parse(meta);
   } catch(error) {
     parsedMeta = meta.toString();
-  } 
+  }
   return parsedMeta;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifit/winston-express",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ifit/winston-express",
+  "version": "0.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "uglify-js": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz",
+      "integrity": "sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ifit/winston-express",
   "description": "Express middleware to let you use winston from the browser.",
   "author": "Adam Blackburn <adam@ifit.com>",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "index.js",
   "keywords": [
     "winston",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "author": "Adam Blackburn <adam@ifit.com>",
   "version": "0.1.2",
   "main": "index.js",
-  "keywords": ["winston", "logging", "client-log"],
+  "keywords": [
+    "winston",
+    "logging",
+    "client-log"
+  ],
   "contributors": {
     "name": "Kersten Burkhardt <burkhardt@mhp-net.de>"
   },
   "dependencies": {
-    "uglify-js": "~2.x"
+    "uglify-js": "^3.14.3"
   },
   "repository": "git://github.com/ifit/winston-express.git",
   "homepage": "https://github.com/ifit/winston-express"


### PR DESCRIPTION
We noticed a problem this morning with authentication in the monolith (local environment only, thankfully). This package was throwing an error and preventing authentication from persisting across requests. Ultimately, the problem was traced to the use of `uglify-js` to dynamically compress the client code from this module.

In short, `uglify-js` was updated to version 3.14.3 on the monolith. This version has some breaking API changes and, since this module was relying on the monolith for `uglify-js`, it failed.

The solution was to rewrite the call to `uglify-js` in the `index.js` file to change it from passing the `client.js` path (which is no longer supported) to reading the file directly and passing to code to `uglify-js`.